### PR TITLE
refactor: :recycle: Update database to use user ids

### DIFF
--- a/src/_commands/admin/question.ts
+++ b/src/_commands/admin/question.ts
@@ -1,5 +1,5 @@
 import { ROLES } from "../../lib/contants";
-import { sendQuestion } from "../../lib/helpers";
+import { sendAnswer, sendQuestion } from "../../lib/helpers";
 import SlashCommand, { PermissionType } from "../../modules/SlashCommand";
 
 export default new SlashCommand({
@@ -13,6 +13,8 @@ export default new SlashCommand({
         },
     ],
     async execute(interaction) {
-        return sendQuestion(interaction.client);
+        sendAnswer(interaction.client);
+        sendQuestion(interaction.client);
+        return interaction.reply({ ephemeral: true, content: "Successfully send answer and question" });
     },
 });

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -1,0 +1,24 @@
+import { BaseEntity, Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+
+@Entity("users")
+export class User extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    id!: number;
+
+    @Column()
+    userId!: string;
+
+    @Column()
+    name!: string;
+
+    @CreateDateColumn()
+    createdAt!: Date;
+
+    @UpdateDateColumn()
+    updatedAt!: Date;
+
+    constructor(model?: Partial<User>) {
+        super();
+        Object.assign(this, model);
+    }
+}

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -2,7 +2,7 @@ import { Client, TextChannel } from "discord.js";
 import { Config } from "../entity/Config";
 import Event from "@/modules/Event";
 import colors from "colors";
-import { CHANNELS, GUILD_ID } from "@/lib/contants";
+import { CHANNELS } from "@/lib/contants";
 
 export default new Event({
     name: "ready",

--- a/src/features/playground.ts
+++ b/src/features/playground.ts
@@ -1,8 +1,5 @@
-import { Answer } from "../entity/Answer";
+import { Brain } from "../entity/Brain";
 import { Client } from "discord.js";
-import { readdirSync, readFileSync } from "fs";
-import { join } from "path";
-import { sendAnswer } from "../lib/helpers";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default async (client: Client) => {


### PR DESCRIPTION
Use `user.id` instead of `user.toString()` to store user data to prevent bugs from happening when a user changes their nickname